### PR TITLE
Fix omos multicolumn css

### DIFF
--- a/src/Resources/public/backend.scss
+++ b/src/Resources/public/backend.scss
@@ -63,6 +63,7 @@ fieldset.tl_box .heightAuto {
         }
     }
 	
+    
 	h3 {
 		display: none;
 	}

--- a/src/Resources/public/backend.scss
+++ b/src/Resources/public/backend.scss
@@ -62,6 +62,10 @@ fieldset.tl_box .heightAuto {
             }
         }
     }
+	
+	h3 {
+		display: none;
+	}
 }
 
 #pal_geo_legend {
@@ -85,3 +89,4 @@ fieldset.tl_box .heightAuto {
         }
     }
 }
+	


### PR DESCRIPTION
If you have https://github.com/OMOSde/contao-om-backend installed, the the layout of the multicolumn-wizard will be destroyed. 
![Bildschirmfoto 2021-07-21 um 14 37 16 min](https://user-images.githubusercontent.com/1564251/126491060-61ba81ce-91bf-48d4-b950-62a589c6dde0.png)

I changed SCSS only, so please generate the stylesheet for me.